### PR TITLE
specify python2

### DIFF
--- a/ggposrv.py
+++ b/ggposrv.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 #
 # open source ggpo server (re)implementation


### PR DESCRIPTION
On many modern systems `python` is a symlink to `python3`. This avoids having to edit the shebang of `ggposrv.py` by hand.
